### PR TITLE
Fix Alexander_UMFPACK single-value Alexander() to return its results

### DIFF
--- a/src/KnotInvariants/Alexander_UMFPACK.hpp
+++ b/src/KnotInvariants/Alexander_UMFPACK.hpp
@@ -93,9 +93,9 @@ namespace Knoodle
         template<typename ExtScal, IntQ ExtInt>
         void Alexander(
             cref<PD_T> pd,
-            ExtScal arg,
-            ExtScal mantissa,
-            ExtInt  exponent,
+            ExtScal       arg,
+            mref<ExtScal> mantissa,
+            mref<ExtInt>  exponent,
             bool multiply_toQ
         ) const
         {


### PR DESCRIPTION
Hi Henrik,

One more small one from the same testing work, this time in `Alexander_UMFPACK`.

The single-value overload `Alexander(pd, arg, mantissa, exponent, multiply_toQ)` takes its `mantissa` and `exponent` outputs by value:

```cpp
ExtScal mantissa,
ExtInt  exponent,
```

The inner `Alexander_Strands` writes the result through `mref<>` references, but because the public overload holds its own by-value copies, the computed values don't make it back to the caller. (The by-pointer batch overload just below is unaffected and works perfectly.) Passing them by mutable reference fixes it and matches `Alexander_Strands`:

```cpp
mref<ExtScal> mantissa,
mref<ExtInt>  exponent,
```

I verified the single-value call now returns the determinant (-3 for the trefoil at t = -1), matching the batch overload. As always, please feel free to adjust the approach or close this if you'd prefer to handle it differently. Thanks again for the library!
