### PR TITLE
tools: portable interactive-terminal check (Windows build support)

### DIFF
--- a/tools/knoodle_io.hpp
+++ b/tools/knoodle_io.hpp
@@ -25,6 +25,15 @@
 #include <variant>
 #include <vector>
 
+// Interactive-terminal detection: POSIX isatty/fileno vs Windows _isatty/_fileno.
+// Centralized here so the three tools build unchanged on macOS, Linux, and Windows.
+#include <cstdio>       // stdin, fileno
+#ifdef _WIN32
+#  include <io.h>       // _isatty, _fileno
+#else
+#  include <unistd.h>   // isatty, fileno
+#endif
+
 //==============================================================================
 // Type Aliases
 //==============================================================================
@@ -40,6 +49,25 @@ using Clock       = std::chrono::steady_clock;
 using Duration    = std::chrono::duration<double>;
 
 namespace {
+
+//==============================================================================
+// Terminal Utilities
+//==============================================================================
+
+/**
+ * @brief Is stdin connected to an interactive terminal?
+ *
+ * Wraps POSIX isatty/fileno and their Windows _isatty/_fileno equivalents so
+ * the tools' "reading from stdin…" hint behaves identically on both platforms.
+ */
+inline bool StdinIsInteractive()
+{
+#ifdef _WIN32
+    return _isatty(_fileno(stdin)) != 0;
+#else
+    return isatty(fileno(stdin)) != 0;
+#endif
+}
 
 //==============================================================================
 // Timing Utilities

--- a/tools/knoodledraw.cpp
+++ b/tools/knoodledraw.cpp
@@ -29,8 +29,6 @@
 #include <map>
 #include <set>
 
-#include <unistd.h>   // isatty / fileno -- notice when reading from an interactive tty
-
 //==============================================================================
 // Configuration
 //==============================================================================
@@ -2253,7 +2251,7 @@ int main(int argc, char* argv[])
     {
         // No input files — read from stdin (Unix filter mode). If stdin is an
         // interactive terminal, say so, so a bare invocation does not look hung.
-        if (isatty(fileno(stdin)))
+        if (StdinIsInteractive())
         {
             std::cerr << "knoodledraw: reading diagrams from stdin (Ctrl-D to end). "
                          "Pipe a stream or pass a file; --help for usage.\n";

--- a/tools/knoodleidentify.cpp
+++ b/tools/knoodleidentify.cpp
@@ -34,8 +34,6 @@
 #include <tuple>
 #include <vector>
 
-#include <unistd.h>   // isatty / fileno -- notice when reading from an interactive tty
-
 //==============================================================================
 // Configuration
 //==============================================================================
@@ -652,7 +650,7 @@ int main(int argc, char* argv[])
     {
         // Unix filter: no files -> read stdin. If stdin is an interactive terminal
         // (no pipe/redirect), say so, so a bare invocation does not just look hung.
-        if (isatty(fileno(stdin)))
+        if (StdinIsInteractive())
         {
             Log("knoodleidentify: reading diagrams from stdin (Ctrl-D to end). "
                 "Pipe a stream or pass a file; --help for usage.");

--- a/tools/knoodlesimplify.cpp
+++ b/tools/knoodlesimplify.cpp
@@ -34,8 +34,6 @@
 #include <cstdio>
 #include <filesystem>
 
-#include <unistd.h>   // isatty / fileno -- notice when reading from an interactive tty
-
 //==============================================================================
 // Configuration
 //==============================================================================
@@ -1033,7 +1031,7 @@ int main(int argc, char* argv[])
         // Read from stdin. In streaming mode Log is redirected to a file, so write
         // the interactive-tty notice straight to stderr (else a bare invocation of
         // `knoodlesimplify --streaming-mode` just looks hung).
-        if (isatty(fileno(stdin)))
+        if (StdinIsInteractive())
         {
             std::cerr << "knoodlesimplify: reading diagrams from stdin (Ctrl-D to end). "
                          "Pipe a stream or pass a file; --help for usage.\n";


### PR DESCRIPTION
## What

Centralizes the three CLI tools' interactive-terminal detection in a single
`StdinIsInteractive()` helper in `tools/knoodle_io.hpp`, guarded `#ifdef _WIN32`
(`<io.h>` `_isatty`/`_fileno`) vs POSIX (`<unistd.h>` `isatty`/`fileno`). Drops the
per-file `<unistd.h>` includes and the direct `isatty(fileno(stdin))` calls.

## Why

`<unistd.h>` / `isatty` / `fileno` do not exist on Windows, which blocks a native
(clang) Windows build of the CLI tools. This was the only POSIX-ism in the tools.
Motivation: a cross-platform Mathematica paclet that ships the tools as per-platform
binaries, including Windows.

## Scope

`tools/` only — 4 files. No changes to `src/`, `submodules/`, or `legacy/`. No
behavior change on macOS/Linux.

## Verification

- `make all` builds all three tools clean on macOS.
- Full Tier 1 correctness suite: 2495/2495 (against latest Tensors).
- Streaming pipeline `knoodlesimplify --streaming-mode | knoodleidentify` still
  identifies ExampleKnot correctly.

Prepared with Claude Code (Opus 4.8)