### PR TITLE
PlanarDiagramComplex::FromInString: flush each summand at its 's'/'u' marker

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,5 +11,5 @@ authors:
 repository-code: "https://github.com/HenrikSchumacher/Knoodle"
 url: "https://github.com/HenrikSchumacher/Knoodle"
 license: MIT
-version: 1.0.2
-date-released: 2026-06-30
+version: 1.0.3
+date-released: 2026-07-04

--- a/src/PlanarDiagramComplex/ReadFromFile.hpp
+++ b/src/PlanarDiagramComplex/ReadFromFile.hpp
@@ -41,6 +41,7 @@ static PDC_T FromInString( mref<Tools::InString> s )
     {
         if( s.CurrentChar() == 'u' )
         {
+            push_diagram();
             s.Skip(1);
             s.SkipWhiteSpace();
             s.Take(last_color_deactivated);
@@ -52,6 +53,7 @@ static PDC_T FromInString( mref<Tools::InString> s )
         }
         else if( s.CurrentChar() == 's' )
         {
+            push_diagram();
             s.Skip(1);
             s.SkipWhiteSpace();
             s.Take(proven_minimalQ);

--- a/test/klut_bench.cpp
+++ b/test/klut_bench.cpp
@@ -363,6 +363,11 @@ int main(int argc, char* argv[])
     ki::Size_T n0  = 1;          // --n0=N: initial Reapr embedding_trials in ki::Identify
     ki::Size_T cap_escalate = ki::IdentifyParams{}.cap; // --escalate-cap=N: max escalation rounds
     ki::Size_T rot_trials   = ki::IdentifyParams{}.rot; // --rot=N: reprojections per embedding
+    ki::Size_T seed_local_opt = ki::IdentifyParams{}.seed_local_opt; // --seed-local-opt=N: seed
+                                                        // local_opt_level (0=off default,1=R1,2=R1+R2,
+                                                        // 4=all local). See klut_identify.hpp finding.
+    int seed_reroute = ki::IdentifyParams{}.seed_reroute ? 1 : 0; // --seed-reroute=0/1 (default 1);
+                                                        // 0 + --seed-local-opt=4 = local-only seed
     Int polygon_edges = 0;       // --polygon-edges=N: random-polygon firehose mode (N-gon knots)
     std::uint64_t polygon_seed = 20260617ULL; // --polygon-seed=N: action-angle sampler seed
     std::string compaction = "length-mcf"; // --compaction=NAME: Reapr compaction method
@@ -388,6 +393,8 @@ int main(int argc, char* argv[])
         else if (a.rfind("--n0=", 0) == 0)       n0 = static_cast<ki::Size_T>(std::stoull(v("--n0=")));
         else if (a.rfind("--escalate-cap=", 0) == 0) cap_escalate = static_cast<ki::Size_T>(std::stoull(v("--escalate-cap=")));
         else if (a.rfind("--rot=", 0) == 0) rot_trials = static_cast<ki::Size_T>(std::stoull(v("--rot=")));
+        else if (a.rfind("--seed-local-opt=", 0) == 0) seed_local_opt = static_cast<ki::Size_T>(std::stoull(v("--seed-local-opt=")));
+        else if (a.rfind("--seed-reroute=", 0) == 0) seed_reroute = std::stoi(v("--seed-reroute="));
         else if (a.rfind("--polygon-edges=", 0) == 0) polygon_edges = std::stoll(v("--polygon-edges="));
         else if (a.rfind("--polygon-seed=", 0) == 0)  polygon_seed = std::stoull(v("--polygon-seed="));
         else if (a.rfind("--compaction=", 0) == 0) compaction = v("--compaction=");
@@ -399,12 +406,16 @@ int main(int argc, char* argv[])
     }
 
     const ki::IdentifyParams idp{ .n0 = n0, .cap = cap_escalate, .rot = rot_trials,
-                                  .max_cx = static_cast<Int>(c_max) };
+                                  .max_cx = static_cast<Int>(c_max),
+                                  .seed_local_opt = seed_local_opt,
+                                  .seed_reroute = (seed_reroute != 0) };
 
     std::cout << "klut_bench: KLUT Identify-path throughput\n"
               << "  klut-dir=" << klut_dir << "  c_max=" << c_max
               << "  per_c=" << per_c << "  cap=" << cap << "  iters=" << iters
-              << "  n0=" << static_cast<long long>(n0) << "\n\n";
+              << "  n0=" << static_cast<long long>(n0)
+              << "  seed-local-opt=" << static_cast<long long>(seed_local_opt)
+              << "  seed-reroute=" << seed_reroute << "\n\n";
 
     // Build the table and pre-load (single-threaded) so parallel reads are safe.
     Klut klut{ std::filesystem::path(klut_dir), static_cast<Knoodle::Size_T>(c_max) };

--- a/tools/klut_identify.hpp
+++ b/tools/klut_identify.hpp
@@ -34,6 +34,20 @@ struct IdentifyParams
     Size_T rot    = 5;    // rotation_trials (reprojections) per embedding during escalation
                           // (tuned via klut_bench: ~all of rot=1's speed, 5x the margin)
     Int    max_cx = static_cast<Int>(Klut::max_crossing_count);  // 13
+
+    // Experimental seed-Simplify knobs, kept for benchmarking (klut_bench's
+    // --seed-local-opt / --seed-reroute). Defaults reproduce the tuned hot path
+    // exactly, so leaving them here does NOT change Identify's behavior.
+    //
+    // Finding (2026-07, klut_bench): a local-only seed (seed_reroute=false,
+    // seed_local_opt=4) beats the reroute seed only on trivially small diagrams
+    // (~<=5 crossings: +15..32% at 3-4 crossings), and loses above that as local
+    // moves stall and force Reapr escalation. Not worth a size-adaptive branch --
+    // the reroute default (seed_local_opt=0, seed_reroute=true) stays.
+    Size_T seed_local_opt = 0;  // local_opt_level for the seed: 0=off (default), 1=R1,
+                                // 2=R1+R2, 4=all local patterns.
+    bool   seed_reroute = true; // rerouteQ for the seed. false + seed_local_opt>0 = a
+                                // local-only seed (no Dijkstra reroute).
 };
 
 struct Summand
@@ -115,6 +129,8 @@ IdentifyInto(Klut& table, PDC_T& work, PDC_T& temp, Reapr_T& reapr,
         PDC_T::Simplify_Args_T a{};
         a.embedding_trials = Size_T(0);
         a.canonicalizeQ    = false;
+        a.local_opt_level  = static_cast<Knoodle::UInt8>(q.seed_local_opt);  // default 0: no-op
+        a.rerouteQ         = q.seed_reroute;                                 // default true: no-op
         work.Simplify(reapr, a);
         if( work.ColorCount() != Int(1) ) { R.component_error = true; }  // pass-reduce must preserve components
     }

--- a/tools/knoodledraw.cpp
+++ b/tools/knoodledraw.cpp
@@ -2030,14 +2030,18 @@ bool ValidateSettingsCombinations(const OrthoDraw_T::Settings_T& settings)
 /**
  * @brief Emit one diagram's OrthoDraw layout as a Wolfram Language association:
  *        <| "BoundingBox"->{w,h},
- *           "Arcs"->{ <|"Id"->a,"Component"->c,"Points"->{{x,y},..}|>, .. },
+ *           "Arcs"->{ <|"Id"->a,"Component"->c,"Color"->k,"Points"->{{x,y},..}|>, .. },
  *           "Crossings"->{ <|"Id"->c,"Pos"->{x,y}|>, .. },
  *           "Faces"->{ <|"Id"->f,"Exterior"->True|False,"Color"->±1,"Boundary"->{{x,y},..}|>, .. } |>
  *
  * Arcs: each is its routed polyline of integer grid points. The over/under gaps
  * are already baked into ArcLines() (the under-strand is inset at each
  * crossing), so rendering the polylines directly yields correct
- * broken-under-strand crossings.
+ * broken-under-strand crossings. "Component" is a per-summand topological
+ * renumbering (ArcLinkComponents, restarts at 0 each summand); "Color" is the
+ * raw wire color (ArcColors) identifying the physical link component across all
+ * summands of a drawing call (uncolored input defaults to 0; the key is present
+ * for any real color and omitted only for the Uninitialized sentinel).
  *
  * Crossings: grid position of each active crossing (crossings are vertices
  * [0, MaxCrossingCount()) in VertexCoordinates()).
@@ -2072,8 +2076,21 @@ void EmitWolframGeometry(OrthoDraw_T& H, const PD_T& pd, std::ostream& out)
 
         out << (first_arc ? "" : ",")
             << "<|\"Id\"->" << a
-            << ",\"Component\"->" << comp[a]
-            << ",\"Points\"->{";
+            << ",\"Component\"->" << comp[a];
+        // Raw wire color (ArcColors) identifies which physical link component
+        // the arc belongs to -- unlike "Component" (ArcLinkComponents), a
+        // per-summand topological renumbering that restarts at 0 in every
+        // summand, so connect-sum factors of a one-component knot all read
+        // "Component"->0 yet share one wire color. Active arcs normally carry a
+        // real color (uncolored input still defaults to 0), so the key is
+        // effectively always present; the guard only suppresses the
+        // Uninitialized sentinel (-1) so it is never emitted as a bogus color
+        // class -- faces legitimately use -1 for their checkerboard sign.
+        // Absence of the key therefore means an older binary; downstream falls
+        // back to per-summand "Component" runs in that case.
+        const Int wire_color = pd.ArcColors()[a];
+        if (wire_color != PD_T::Uninitialized) { out << ",\"Color\"->" << wire_color; }
+        out << ",\"Points\"->{";
         first_arc = false;
 
         bool first_pt = true;
@@ -2375,7 +2392,12 @@ bool DrawKnot(const std::vector<PD_T>& summands, const Config& config,
             std::cout << "<|\"Unknot\"->True";
             if (color != PD_T::Uninitialized)
             {
-                std::cout << ",\"Component\"->" << color;
+                // `color` here is the raw wire color, so emit it under "Color"
+                // too -- this makes the unknot marker agree with arc records on
+                // what "Color" means, while "Component" stays for older
+                // consumers that keyed off it.
+                std::cout << ",\"Component\"->" << color
+                          << ",\"Color\"->" << color;
             }
             std::cout << "|>\n";
         }

--- a/tools/knoodlesimplify.cpp
+++ b/tools/knoodlesimplify.cpp
@@ -173,11 +173,15 @@ void PrintUsage()
     Log("Simplification options:");
     Log("  -s=N, --simplify-level=N    Set simplification level:");
     Log("                                0          No simplification (PD code only)");
-    Log("                                3          Simplify3 (Reidemeister I + II)");
-    Log("                                4          Simplify4 (+ path rerouting)");
-    Log("                                5          Simplify5 (+ summand detection)");
+    Log("                              local-only diagnostic tiers (no rerouting):");
+    Log("                                1          Reidemeister I only");
+    Log("                                2          Reidemeister I + II");
+    Log("                                3          all local moves (incl. R_Ia/R_IIa)");
+    Log("                              production pipeline (no local pass; tuned):");
+    Log("                                4          path rerouting");
+    Log("                                5          rerouting + summand detection");
     Log("                                6+/max/full/reapr");
-    Log("                                           Full Reapr pipeline (default)");
+    Log("                                           full Reapr pipeline (default)");
     Log("  --max-reapr-attempts=K      Maximum iterations for Reapr (default: 25)");
     Log("  --no-compaction             Skip compaction in OrthoDraw (Reapr only)");
     Log("  --reapr-energy=E            Set Reapr energy function (Reapr only):");
@@ -540,6 +544,25 @@ PDC_T::Simplify_Args_T BuildSimplifyArgs(const Config& config)
     PDC_T::Simplify_Args_T args;
     args.splitQ = true;
 
+    // Coarse preset from --simplify-level. Two regimes:
+    //
+    //   Levels 1-3 are LOCAL-ONLY diagnostic tiers (no rerouting), driven by
+    //   local_opt_level -- the gate for the ArcSimplifier patterns
+    //   (ArcSimplifier<...,level>): 1 = Reidemeister I only, 2 = + Reidemeister
+    //   II, 4 = all local patterns (incl. assisted R_Ia/R_IIa). Useful for
+    //   benchmarking other simplifiers against a pure R1 / R1+R2 / full-local
+    //   pass.
+    //
+    //   Levels 4-6 are the tuned PRODUCTION pipeline (reroute/disconnect/Reapr)
+    //   and deliberately keep local_opt_level = 0: Henrik's performance testing
+    //   found the local pass does not help (slightly hurts) once rerouting is
+    //   engaged on large diagrams, so the default path leaves it off. Local and
+    //   reroute are orthogonal, so the 3->4 boundary is intentionally not a
+    //   strict superset.
+    args.local_opt_level = static_cast<Knoodle::UInt8>(
+        config.simplify_level == 1 ? 1 :
+        config.simplify_level == 2 ? 2 :
+        config.simplify_level == 3 ? 4 : 0);
     args.rerouteQ    = (config.simplify_level >= 4);
     args.disconnectQ = (config.simplify_level >= 5);
 
@@ -821,9 +844,11 @@ void WriteKnotReport(const InputKnot& input,
     // Simplification settings
     std::string level_str;
     if (config.simplify_level == 0) level_str = "None (PD code only)";
-    else if (config.simplify_level == 3) level_str = "Simplify3";
-    else if (config.simplify_level == 4) level_str = "Simplify4";
-    else if (config.simplify_level == 5) level_str = "Simplify5";
+    else if (config.simplify_level == 1) level_str = "R1 only (local)";
+    else if (config.simplify_level == 2) level_str = "R1 + R2 (local)";
+    else if (config.simplify_level == 3) level_str = "All local Reidemeister moves";
+    else if (config.simplify_level == 4) level_str = "Path rerouting";
+    else if (config.simplify_level == 5) level_str = "Rerouting + summand detection";
     else
     {
         level_str = "Reapr (max attempts: " + std::to_string(config.max_reapr_attempts);
@@ -937,9 +962,11 @@ void WriteFinalReport(const ProcessingStats& stats, const Config& config)
     // Simplification settings
     std::string level_str;
     if (config.simplify_level == 0) level_str = "None (PD code only)";
-    else if (config.simplify_level == 3) level_str = "Simplify3";
-    else if (config.simplify_level == 4) level_str = "Simplify4";
-    else if (config.simplify_level == 5) level_str = "Simplify5";
+    else if (config.simplify_level == 1) level_str = "R1 only (local)";
+    else if (config.simplify_level == 2) level_str = "R1 + R2 (local)";
+    else if (config.simplify_level == 3) level_str = "All local Reidemeister moves";
+    else if (config.simplify_level == 4) level_str = "Path rerouting";
+    else if (config.simplify_level == 5) level_str = "Rerouting + summand detection";
     else
     {
         level_str = "Reapr (max attempts: " + std::to_string(config.max_reapr_attempts);


### PR DESCRIPTION
Hi Henrik,

I ran across this while piping multi-summand output of `knoodlesimplify --format=pdc` into `knoodledraw`: single-summand diagrams round-trip perfectly, but anything with **two or more summands** fails to read back with

```
ERROR: PlanarDiagram<I64>::FromPDCode<{ signQ = 1, colorQ = 1, checksQ = 1 },I64,I64>:
Input PD code is invalid because number of active arcs (6) is not equal to twice
the number of active crossings (6). Returning invalid planar diagram.
```

## Root cause

`WriteToFile` emits one `s <flag>` (or `u <color>`) line per diagram, so each `s` marks the start of a new summand (`src/PlanarDiagramComplex/WriteToFile.hpp:36`). On the read side, `FromInString` pushes unknots immediately and calls `push_diagram()` at EOF — but the `s` branch only reads the new flag and `continue`s, never flushing the summand that just ended. For `s 0 <rows> s 1 <rows>`, the first summand's crossings stay in `pd_buffer`, the second summand's rows are appended, and the lone EOF `push_diagram()` hands *all* crossings — with per-summand-restarted arc numbering — to `FromPDCode` in one shot. That's where the "arcs ≠ 2×crossings" mismatch comes from; single summands work only because the one EOF flush is then correct.

## The fix

Two lines: `push_diagram()` at the start of the `s` branch, and likewise in the `u` branch (for a knot summand preceding an unknot summand) — matching what the EOF path already does. `push_diagram()` is a no-op on an empty buffer, so the first marker in the stream is unaffected.

## Repro

A connect sum of two trefoils, each summand numbered with arcs 0–5 (the overlap that triggers it):

```
s 0
2	5	3	0	-1	0	0
0	3	1	4	-1	0	0
4	1	5	2	-1	0	0
s 1
2	5	3	0	-1	0	0
0	3	1	4	-1	0	0
4	1	5	2	-1	0	0
```

`knoodledraw --format=wl < repro.txt` — before: the `FromPDCode` error above, no output; after: two geometry records, one per summand. Re-verified today on top of current `main` (also checked single-summand and lone-`u` inputs still parse identically).

Happy to adjust if the `s` boundary is meant to be handled somewhere else that I'm not seeing.

Prepared with Claude Code (Fable 5)