### PR TITLE
PolyFold/makefile: revert Darwin CXX to portable clang++

### DIFF
--- a/PolyFold/makefile
+++ b/PolyFold/makefile
@@ -5,7 +5,7 @@ CXX ?= g++
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
     # macOS - use clang with matrix extensions
-    CXX = /opt/homebrew/Cellar/llvm@18/18.1.8/bin/clang++
+    CXX = clang++
     CXXFLAGS = -Wall -Wextra -std=c++20 -O3 -march=native -mtune=native \
                -fenable-matrix -pthread -DPOLYFOLD_NO_QUATERNIONS
 else ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
## Summary
- The Darwin branch of `PolyFold/makefile` hardcoded `CXX` to an absolute path into one machine's Homebrew Cellar (`/opt/homebrew/Cellar/llvm@18/18.1.8/bin/clang++`), introduced in 128a2f3.
- This is a regression from 1.0.2's portable `CXX = clang++` (resolved via `PATH`). `tools/Makefile`'s Darwin branch was never touched and still uses the portable form.
- A plain `make` in `PolyFold/` fails on any Mac that isn't the exact release machine — including the `cantarellalab` Homebrew tap's build (macOS CI runner and end users), since that Cellar path doesn't exist anywhere else.
- Apple's system clang already supports `-fenable-matrix` (confirmed: `clang++ -fenable-matrix -std=c++20` compiles cleanly with Apple clang 21), so there's no need to pin a specific `llvm@18` build on macOS at all.

## Test plan
- [x] `grep -n "CXX = " PolyFold/makefile` shows `CXX = clang++` on the Darwin branch, matching `tools/Makefile`.
- [x] Henrik: confirm `make` in `PolyFold/` still builds cleanly on your machine with this change (it should just resolve `clang++` via `PATH` as before, picking up whichever clang toolchain you have there).

Full writeup with repro/context in `handoff/polyfold-macos-hardcoded-clang-path/ROUND-1.md` on our side.

Prepared with Claude Code (Sonnet 5)