### PR TITLE
Fix uninitialized read of crossing_ptr[0] in PlanarDiagramComplex::Union()

### DIFF
--- a/src/PlanarDiagramComplex/Unite.hpp
+++ b/src/PlanarDiagramComplex/Unite.hpp
@@ -6,7 +6,9 @@ void Unite()
 PDC_T Union() const
 {
     Tensor1<Int,Size_T> crossing_ptr ( DiagramCount() + Int(1) );
-    
+    crossing_ptr[0] = 0;    // seed the prefix sum; else crossing_ptr[0] is read
+                            // uninitialized below (as at the sibling *_ptr sites)
+
     const Size_T diagram_count = Size_T(DiagramCount());
     
     Int crossing_count = 0;


### PR DESCRIPTION
One-line correctness fix, independent of any CI work.

## The bug
`PlanarDiagramComplex::Union()` (`src/PlanarDiagramComplex/Unite.hpp`) builds `crossing_ptr` as a cumulative-offset array but never seeds its base element:

```cpp
Tensor1<Int,Size_T> crossing_ptr ( DiagramCount() + Int(1) );   // allocated, uninitialized
...
for( Size_T idx = 0; idx < diagram_count; ++idx )
    crossing_ptr[idx+1] = crossing_ptr[idx] + pd.max_crossing_count;   // idx=0 reads [0]
```

The `idx=0` iteration reads `crossing_ptr[0]`, which was never assigned.

- **macOS**: freshly-mapped pages read as zero, so the prefix sum is correct *by luck*.
- **Linux** (glibc returns dirty memory): `crossing_ptr[0]` is garbage → `crossing_ptr.Last()` is garbage → `PlanarDiagram( crossing_ptr.Last(), true )` computes `max_arc_count = 2 * garbage` (`PlanarDiagram.hpp:195`, signed overflow) → multi-GB `aligned_malloc` → **crash**.

Reached via `ToSingleDiagram() → Connect() → ConnectedSum() → Union()`, so any link / connected-sum path can hit it — **including the shipping `knoodlesimplify` / `knoodleidentify` tools built on Linux**, not just tests.

## The fix
Seed `crossing_ptr[0] = 0` before the loop. This restores the idiom **your own code already uses at every other cumulative-offset site**:

- `src/ConformalBarycenterSampler.hpp:399` — `component_ptr[0] = 0;`
- `src/ActionAngleSampler.hpp:447` — `component_ptr[0] = 0;`
- `src/Link.hpp:88` — `component_ptr[0] = 0;`
- `src/KnotEmbedding.hpp:120` — `component_ptr[0] = 0;`
- `legacy/Reapr_Legacy/Generate.hpp:166` — `output_ptr[0] = 0;`

`Union()` was the sole omission. I swept every `X[i+1] = X[i] + …` prefix-sum in `src/` + `legacy/`; this is the only unseeded one. (`Link.hpp:449`’s `edge_ptr` is a different construct — pre-filled as a permutation and deliberately aliased, not uninitialized.)

## Verification
- Root-caused with **AddressSanitizer + UBSan** on Fedora (UBSan flags the `2 * garbage` overflow at `PlanarDiagram.hpp:195`, backtrace through `Union → ConnectedSum → Connect → ToSingleDiagram`).
- Reproduced the crash on **Ubuntu (clang)**, **Fedora (gcc)**, and **Rocky 9 (clang)**.
- With the seed, the HOMFLY-invariance panel and the exhaustive `plantri_check` (51,416 diagrams, c≤6, incl. all link cases) pass on all three.

Found while standing up build+test CI for this repo across the Homebrew tap’s platforms (that CI comes as a separate follow-up PR, gated on this fix).

Prepared with Claude Code (Opus 4.8)