### PR TITLE
Scope knoodle_io timing aliases to avoid Apple Duration clash

### DIFF
--- a/tools/knoodle_io.hpp
+++ b/tools/knoodle_io.hpp
@@ -48,8 +48,18 @@ using OrthoDraw_T = Knoodle::OrthoDraw<PD_T>;
 using Energy_T    = PDC_T::Energy_T;
 using LinkEmb_T   = Knoodle::LinkEmbedding<Real, Int, float>;
 using Reapr_T     = Knoodle::Reapr<Real, Int, float>;  // only used for RandomRotation()
-using Clock       = std::chrono::steady_clock;
-using Duration    = std::chrono::duration<double>;
+
+// The timing aliases live in a named namespace rather than at global scope.
+// Apple's <MacTypes.h> (pulled in transitively by <Accelerate/Accelerate.h>,
+// which the UMFPACK/Alexander path force-includes) declares `typedef SInt32
+// Duration;` at global scope. A global `using Duration = ...` here is then a
+// conflicting typedef redefinition. Downstream tools that combine this shared
+// header with the Accelerate backend are the first TU to meet both, so keep
+// these two aliases scoped. The vocabulary aliases above stay global on purpose.
+namespace knoodle_io {
+    using Clock    = std::chrono::steady_clock;
+    using Duration = std::chrono::duration<double>;
+} // namespace knoodle_io
 
 namespace {
 
@@ -82,17 +92,17 @@ inline bool StdinIsInteractive()
 class ScopedTimer
 {
 public:
-    explicit ScopedTimer(Duration& target)
-        : target_(target), start_(Clock::now()) {}
+    explicit ScopedTimer(knoodle_io::Duration& target)
+        : target_(target), start_(knoodle_io::Clock::now()) {}
 
     ~ScopedTimer()
     {
-        target_ = Clock::now() - start_;
+        target_ = knoodle_io::Clock::now() - start_;
     }
 
 private:
-    Duration& target_;
-    Clock::time_point start_;
+    knoodle_io::Duration& target_;
+    knoodle_io::Clock::time_point start_;
 };
 
 //==============================================================================

--- a/tools/knoodlesimplify.cpp
+++ b/tools/knoodlesimplify.cpp
@@ -41,6 +41,12 @@
 
 namespace {
 
+// The timing aliases moved into namespace knoodle_io (see knoodle_io.hpp) to
+// avoid a global-scope clash with Apple's <MacTypes.h> `Duration`. This tool
+// never pulls in the Accelerate backend, so bringing the alias local to this
+// anonymous namespace is safe and keeps the timing fields below unqualified.
+using knoodle_io::Duration;
+
 /**
  * @brief Configuration parsed from command-line arguments.
  */


### PR DESCRIPTION
## Summary

`tools/knoodle_io.hpp` declares two convenience aliases at **global scope**:

```cpp
using Clock    = std::chrono::steady_clock;
using Duration = std::chrono::duration<double>;
```

On macOS, `Duration` collides with Apple's SDK. Any translation unit that
includes `knoodle_io.hpp` **and** pulls in `<Accelerate/Accelerate.h>` (→
`<vecLib/...>` → `<MacTypes.h>`) fails to compile, because `MacTypes.h`
declares at global scope:

```cpp
typedef SInt32 Duration;   // MacTypes.h:288
```

so `knoodle_io.hpp`'s `using Duration = std::chrono::duration<double>;` becomes
a typedef redefinition with a different type.

## Why it's latent in Knoodle but real downstream

The two ingredients never meet inside Knoodle itself:

- The tools that include `knoodle_io.hpp` (`knoodlesimplify`, `knoodledraw`,
  `knoodleidentify`) don't use the UMFPACK/Alexander path, so they never
  force-include a BLAS backend.
- The tests that use the Alexander/UMFPACK path (`klut_check`, `inflate_check`,
  …) force-include `submodules/Tensors/Accelerate.hpp` but don't include
  `knoodle_io.hpp`.

A downstream invariant tool needs **both**: it reuses `knoodle_io.hpp` for the
shared diagram parser and uses `Alexander_UMFPACK<std::complex<double>,
std::int64_t>`, which requires the Accelerate backend force-included. That's the
first TU to combine the two, so it trips the clash.

## Fix

Move only the two `std::chrono` aliases out of global scope into
`namespace knoodle_io` and qualify their uses in `ScopedTimer`. The shared
vocabulary aliases (`Int`, `Real`, `PD_T`, …) **stay global on purpose** — the
tools rely on them.

`knoodlesimplify.cpp` is the only tool that references `Duration` (~11 timing
fields). It never pulls in the Accelerate backend, so it brings the alias local
with a scoped `using knoodle_io::Duration;` inside its anonymous namespace,
keeping those fields unqualified with no churn.

`Clock` moves too, even though Apple doesn't currently define a global `Clock`,
since a future SDK could reopen the same hazard.

## Verification

- The minimal repro (`knoodle_io.hpp` + `-include Accelerate.hpp` +
  `-DKNOODLE_USE_UMFPACK`) that previously errored at `knoodle_io.hpp:52` now
  compiles clean (`-fsyntax-only`).
- `knoodlesimplify`, `knoodledraw`, and `knoodleidentify` all still build via
  `tools/Makefile` (only the pre-existing `WritePdcNativeFormat` unused-function
  warning remains).

Prepared with Claude Code (Opus 4.8)