### PR TITLE
FindIntersections: the interval degeneracy is a warning, not an error

### DIFF
--- a/src/LinkEmbedding/FindIntersections.hpp
+++ b/src/LinkEmbedding/FindIntersections.hpp
@@ -73,7 +73,7 @@ public:
             {
                 if constexpr ( verboseQ )
                 {
-                    eprint(MethodName("FindIntersections")+": Detected " + ToString(count) + " cases where the line-line intersection was degenerate (the intersection set was an interval). Try to randomly rotate the input coordinates.");
+                    wprint(MethodName("FindIntersections")+": Detected " + ToString(count) + " cases where the line-line intersection was degenerate (the intersection set was an interval). Try to randomly rotate the input coordinates.");
                 }
                 return 5;
             }


### PR DESCRIPTION
One character: flag 5 reports with `wprint` instead of `eprint`, matching its two siblings.

```diff
-                    eprint(MethodName("FindIntersections")+": Detected " + ...
+                    wprint(MethodName("FindIntersections")+": Detected " + ...
```

### Why

`FindIntersections` returns 3, 4 and 5 for degeneracies that are properties of the **viewing direction**, not of the link. All three carry word-for-word the same advice — *"Try to randomly rotate the input coordinates"* — and `PlanarDiagramComplex::Rattle` does exactly that, normally succeeding on the next rotation.

| flag | condition | channel |
|---|---|---|
| 7 | intersection times out of bounds | `eprint` |
| 6 | segments intersect **in 3D** | `eprint` |
| **5** | degenerate line-line intersection (an interval) | **`eprint`** → `wprint` |
| 4 | intersection at corners of two segments | `wprint` |
| 2/3 | intersection at a corner of one segment | `wprint` |

The print-level boundary sat between 5 and 4, but the semantic boundary is between 6 and 5: flags 6, 7 and 9 mean broken geometry that no rotation fixes, while 3, 4 and 5 mean an unlucky viewing angle.

### What it costs today

Since the CLI tools started refusing output when the library reports an error, a transient flag 5 that Rattle recovered from cleanly still makes `knoodlesimplify` exit nonzero and declare correct output unreliable. Observed once in 59 runs (~1.7%) on a run that simplified 117 crossings to 115 correctly and never reached Rattle's give-up path at all.

Severity is still conveyed losslessly by the return value, which is the right channel for it — a caller that wants to treat 5 as worse than 3 or 4 still can. The print channel now has a side effect on process exit status, which makes it the wrong place to encode relative severity.

Nothing is silenced: the genuinely fatal case still reports itself, because Rattle `eprint`s once it has exhausted its rotations.

### Scope

Deliberately minimal, and left uncommented — flags 3 and 4 two lines below already use `wprint`, so the consistency is self-evident from context.

The retry loops in Rattle and `Klutter/KnotInfo.hpp` still report conditions they are about to retry, and could be quieted via the existing `RequireIntersections<false>` template parameter. Not done here: the prosector-based intersection resolution is expected to make these degeneracies impossible rather than merely quieter, so it is not worth building on this code path.

### Verification

Full Tier 1 suite: **2495/2495**. All three tools rebuild clean.

Prepared with Claude Code (Opus 5)