### PR TITLE
Fix ArcFaces() doc comment: slot (a,d) is the left face of darc 2a+d

### DIFF
--- a/src/PlanarDiagram/Faces.hpp
+++ b/src/PlanarDiagram/Faces.hpp
@@ -31,7 +31,7 @@ cref<RaggedList<Int,Int>> FaceDarcs() const
     return this->template GetCache<RaggedList<Int,Int>>(tag);
 }
 
-/*!@brief For each arc list the two faces. The convention is that `ArcFaces()(a,1)` is the face to the _right_ of the forward arc `ToDarc(a,Head)` of `a`. This convention may seem odd, but we have to stick to it.*/
+/*!@brief For each arc list the two faces. The convention is that `ArcFaces()(a,d)` is the face to the _left_ of the directed arc `ToDarc(a,d)`; in particular, `ArcFaces()(a,1)` lies to the left of the forward arc `ToDarc(a,Head)` of `a`, and `ArcFaces()(a,0)` to its right. (This matches the "right face first" convention documented in `ComputeFaces`, and the face-on-left orientation of `FaceDarcs()`.)*/
 cref<ArcContainer_T> ArcFaces()  const
 {
     std::string tag ("ArcFaces");


### PR DESCRIPTION
## What

One-sentence doc-comment fix in `src/PlanarDiagram/Faces.hpp` (no code change). The comment on `ArcFaces()` said:

> `ArcFaces()(a,1)` is the face to the _right_ of the forward arc `ToDarc(a,Head)`

but the implemented convention is the opposite. The new comment states:

> `ArcFaces()(a,d)` is the face to the **left** of the directed arc `ToDarc(a,d)` — in particular `(a,1)` lies left of the forward arc, `(a,0)` to its right

which matches both the convention note inside `ComputeFaces` ("Convention: _Right_ face first … This way the directed arc `da = 2 * a + d` has its left face in `dA_f[da]`") and the face-on-left orientation of `FaceDarcs()` documented a few lines above.

## Evidence

Right-hand trefoil `[[0,4,1,3,+],[2,0,3,5,+],[4,2,5,1,+]]` (0-based arcs):

- `FaceDarcs()` reports a face with boundary darc cycle `{3, 11, 7}`. By the face-on-left rule this face lies **left** of darc `11 = ToDarc(5, Head)`.
- `ArcFaces()(5,1)` returns exactly that face; `ArcFaces()(5,0)` returns the face `{5, 10}`.

So slot 1 holds the **left** face of the forward darc, contradicting the old comment and agreeing with `ComputeFaces`.

## Why it matters

We're building tooling on top of the face conventions and initially took this comment at face value — the data disagreed. With a Doxygen/GitHub-Pages documentation site for Knoodle on the horizon, this is exactly the kind of comment that would be harvested into a permanently wrong API-reference page without anyone noticing.

Prepared with Claude Code (Fable 5)