### PR TITLE
Reroute: resolve path arc labels that the loop itself recycles

### DIFF
--- a/src/PlanarDiagramComplex/PassSimplifier.hpp
+++ b/src/PlanarDiagramComplex/PassSimplifier.hpp
@@ -124,7 +124,19 @@ namespace Knoodle
         Stack_T X_front;
         Stack_T Y_front;
         Stack_T prev_front;
-        
+
+        // Scratch for `Reroute`: when its per-crossing loop recycles the label
+        // `a_1`, `A_succ[a_1]` records the label `a_0` that absorbed `a_1`'s
+        // geometric span, so that later entries of the (pre-computed) path can
+        // be redirected. `A_succ` holds `PD_T::Uninitialized` everywhere
+        // between calls -- note that the class-local `Uninitialized` above is
+        // declared `bool`, so it is `1`, a perfectly valid arc label, and must
+        // not be used as a sentinel here. `succ_front` lists the entries a call
+        // dirtied, so the reset at the end of `Reroute` costs O(path length)
+        // rather than O(arc count).
+        Tensor1<Int,Int> A_succ;
+        Stack_T succ_front;
+
         DijkstraStrategy_T strategy = DijkstraStrategy_T::Bidirectional;
         bool overQ;
         bool strand_completeQ;
@@ -168,6 +180,8 @@ namespace Knoodle
             X_front            = Stack_T( max_arc_count );
             Y_front            = Stack_T( max_arc_count );
             prev_front         = Stack_T( max_arc_count );
+            A_succ             = Tensor1<Int,Int>( max_arc_count, PD_T::Uninitialized );
+            succ_front         = Stack_T( max_arc_count );
             
             if constexpr ( hash_mapQ )
             {

--- a/src/PlanarDiagramComplex/PassSimplifier/Reroute.hpp
+++ b/src/PlanarDiagramComplex/PassSimplifier/Reroute.hpp
@@ -4,6 +4,17 @@ private:
  * @brief Attempts to reroute the strand. It is typically not save to call this function without the invariants guaranteed by `SimplifyStrands`. Some of the invariants are correct coloring of the arcs and crossings in the current strand and the absense of possible Reidemeister I and II moves along that strand.
  * This is why we make this function private.
  *
+ * `path` is produced before any mutation happens, so its entries are arc
+ * labels of the _incoming_ diagram. The loop below rewrites the diagram as it
+ * walks, and in doing so it recycles the label `a_1` (see there): `a_1`'s old
+ * geometric span is absorbed into `a_0`, and the label itself is reused for a
+ * piece of `b`. A later path entry naming such a label therefore no longer
+ * denotes the arc the path meant. `A_succ` maps each recycled label to the
+ * label that absorbed its span, and `path` entries are resolved through it.
+ * Without that resolution the loop splices a transversal it should have kept,
+ * and can return a planar, `CheckAll`-clean diagram of a _different knot_
+ * (see `handoff/reroute-arc-label-aliasing`).
+ *
  * @param pass On entry, pass to reroute. On return, the reouted pass.
  */
 
@@ -65,6 +76,8 @@ bool Reroute( mref<Pass_T> pass, mref<Path_T> path )
     
     PD_TIC("While loop for rerouting");
 
+    succ_front.Reset();
+
     while( p < q )
     {
         const Int c_0 = pd->A_cross(a,Head);
@@ -75,6 +88,12 @@ bool Reroute( mref<Pass_T> pass, mref<Path_T> path )
         const Int a_2 = pd->C_arcs(c_0,Out,side);
         PD_VALPRINT("a_2", ArcString(a_2));
         auto [b,left_to_rightQ] = FromDarc(path[p]);
+
+        // `path` was computed on the incoming diagram; redirect `b` if an
+        // earlier iteration recycled its label. Follow chains: an absorbing
+        // `a_0` can itself be recycled by a later crossing.
+        while( A_succ[b] != PD_T::Uninitialized ) { b = A_succ[b]; }
+
 //        PD_VALPRINT("b", ArcString(b));
         
         const Int c_1 = pd->A_cross(b,Head);
@@ -171,6 +190,12 @@ bool Reroute( mref<Pass_T> pass, mref<Path_T> path )
         //             X
         
         Reconnect<Head,false>(a_0,a_1);
+
+        // `a_1`'s span now lives in `a_0`, and the label `a_1` is about to be
+        // reused below. Record the redirection for later `path` entries.
+        A_succ[a_1] = a_0;
+        succ_front.Push(a_1);
+
         pd->ChangeArcColor_Private( a_1, pd->A_color[b] );
         Reconnect<Head,false>(a_1,b  );
         
@@ -272,6 +297,10 @@ bool Reroute( mref<Pass_T> pass, mref<Path_T> path )
         ++p;
     }
     PD_TOC("While loop for rerouting");
+
+    // Restore `A_succ` to all-`PD_T::Uninitialized` for the next call. Only the
+    // entries this call dirtied are touched.
+    while( !succ_front.EmptyQ() ) { A_succ[succ_front.Pop()] = PD_T::Uninitialized; }
 
     [[maybe_unused]] Int deleted_arc_count = CollapseArcRange( a, e, pass.arc_count, pass.mark );
 


### PR DESCRIPTION
`Reroute` takes `path` as arc labels of the diagram it is handed, and then
rewrites that diagram as it walks it. Its per-crossing normal branch splices
the transversal at `c_0` — `Reconnect<Head,false>(a_0,a_1)`, so `a_1`'s
geometric span is absorbed into `a_0` — and then reuses the label `a_1` as a
path-side connector. From that point on, the label `a_1` denotes a different
arc than it did when `path` was computed.

So `Reroute` implicitly promises "hand me a valid pass and a valid corridor
and I will realize that move", but for one family of corridors it doesn't
deliver: if a later `path` entry names a label an earlier iteration recycled,
the loop operates on the wrong arc. The coincidence test `b == a_0 || b ==
a_1` compares against the wrong ports, the normal branch splices a transversal
that should have been kept, and the routine returns a planar, `CheckAll`-clean
diagram of **a different knot**. Nothing in the loop detects it.

### Reproducer

`handoff/reroute-arc-label-aliasing/` (local, not committed) has a native
driver and data. On a 73-crossing determinant-**5** diagram:

- the strand is arcs 40..48 (L = 9), under at all 8 interior crossings — a
  genuine underpass, no RI/RII along it, anchors at crossings 40 and 3;
- the corridor crosses arcs 3, 21, 4, 115, 65, 140, 130, 145, and is a valid
  face path — I traced the faces independently and every consecutive pair is
  cofacial (48 → 69 → 68 → 51 → 55 → 56 → 59 → 60 → 7);
- interior crossing 48 is `[41, 115, 42, 114, +1]`, so `a_0` = 114 and
  `a_1` = 115. The loop reaches it at `p` = 2 and recycles 115; `path[4]`
  then names 115.

Current `Reroute` returns `CheckAll` PASS, 73 crossings, determinant **247**.
With the patch it returns determinant **5**, and the PD code matches, byte for
byte, the code produced by pre-resolving the label by hand.

#### The strand and the proposed corridor, drawn

Heavy strokes are the two actors of the move, light strokes the rest of the
diagram: `w` marks **W**, the strand being rerouted (arcs 40..48), `p` marks
the proposed corridor, and `*` its junctions with the two anchors. Arrows are
the diagram's own, so orientation reads the same everywhere. Where a heavy run
is interrupted by a light stroke, that strand is passing **under**.

```


                 ╭←──────────────────────╮
                 │                       ↑
                 │        ╭─────────────→│─→╮
                 ↓        ↑              ↑  │
              ╭←──←────────←─╮           │  │
              │  │        ↑  ↑           │  │
              │  │     ╭─→──→│─→╮        │  │
              ↓  ↓     ↑  ↑  ↑  │        │  │
  ╭──────────→──→│────→│─→│─→╯  │        │  │
  ↑           ↓  ↓     ↑┏━↑━←┓  ↓        │  ↓
  │  ╭←───────│←─│←────│←─│←─────←────────←──←───────────────────╮
  │  │        │  │ ┏p←━↑┛ ↑  ┗━●↓        ↑  ↓                    ↑
  │  │ ┏━━←━━┓│┏━│━┛┏←━│←━│←━w━━─←────────←──←──────────╮        │
  │  │ ┃     ┗↓┛ ↓  ↓  ↑  ↑     ↓        ↑  ↓           ↑        │
  │  │ ┃╭────→│─→│─→──→│─→│────→────────→──→─────→╮     │        │
  │  │ p↑     ↓  ↓  ↓  ↑  ↑     ↓        ↑  │     │     │        │
  │  │ ┃│  ╭←─│←─│←──←─│←─│←─────←────╮  │  │     │     │        │
  │  │ ┃│  │  │  │  ┃  ↑  ↑     ↓     ↑  │  ↓     ↓     │        │
  │  │ ┃│  │  │  │  w  │  ╰←────│←────│←─│←─│←─────←─────←─╮     │
  │  │ ┃│  │  │  ↓  ↓  │        ↓     ↑  ↑  ↓     ↓     ↑  ↑     │
  │  │ ┃│  │  │  ╰─→──→│───────→│────→│─→│─→│────→──→╮  │  │     │
  │  │ ┃│  │  │     ┃  ↑        │     ↑  ↑  │     │  │  │  │     │
  │  │ ┃│  │  │     ┃  │        │  ╭─→│─→╯  │     │  │  │  │     │
  │  │ ┃│  │  │     ┃  │        ↓  ↑  ↑     ↓     │  │  │  │     │
  │  │ ↓│  │  │     ┃  ╰←───────│←─│←─│←────│←─╮  │  │  │  │     │
  │  │ p│  │  │     w           │  ↑  ↑     ↓  ↑  ↓  │  │  │     │
  │  │ ┃│  │  │     ┃           │  │  ╰←─────←─│←─╯  │  │  │     │
  │  │ ┃│  │  │     ┃           │  │        ↓  ↑     ↓  │  │     │
  │  │ ┃│  │  │     ┃           │  ╰←───────│←─│←────│←──←─│←─╮  │
  │  │ ┃│  ↓  ↓     ↓           ↓           ↓  ↑     │  ↑  ↑  ↑  │
  │  │ ┃│  ╰─→─────→───────────→───────────→──→╯     │  │  │  │  │
  │  │ ┃│     │     ┃           │           ↓        ↓  │  │  │  │
  │  │ ┃│     │     ┃           │           ╰───────→│─→╯  │  │  │
  │  │ ┃│     │     ↓           ↓                    ↓     │  │  │
  │  │ p│     │     ┗━━━━━w━━━━→│━━━━━━━━━w━━━━━━━━━→│━━w━→──→╯  │
  │  │ ┃│     ↓                 ↓                    ↓   ┏●↑     │
  │  │ ┃╰←─────←─────────────────←───────────────────╯┏→━┛ │     │
  │  │ ┗┓     ↓                 ↓      ┏━━━━━━→━━p━━━━┛    │     │
  │  │  ┗━→━━┓╰────────────────→│─────────────────────────→│────→╯
  │  ↓       ┗━━━p━━━━→━━━━p━━━━↓━━→━━p┛                   ↑
  ╰←─│←─────────────────────────╯                          │
     ↓                                                     │
     ╰────────────────────────────────────────────────────→╯


```

That W is a genuine underpass is easier to read off the code than off the
picture — at each of its 8 interior crossings the strand arc is the
under-strand `X[0] -> X[2]`, with the transversal `X[1]`, `X[3]` over it:

| strand arc | crossing | PD row | under | over |
|---|---|---|---|---|
| 40 | 43 | `[40, 20, 41, 19] +1` | 40 → 41 | 19 → 20 |
| 41 | 48 | `[41, 115, 42, 114] +1` | 41 → 42 | **114 → 115** |
| 42 | 47 | `[42, 81, 43, 82] −1` | 42 → 43 | 81 → 82 |
| 43 | 45 | `[43, 99, 44, 98] +1` | 43 → 44 | 98 → 99 |
| 44 | 39 | `[44, 67, 45, 68] −1` | 44 → 45 | 67 → 68 |
| 45 | 33 | `[45, 102, 46, 103] −1` | 45 → 46 | 102 → 103 |
| 46 | 32 | `[46, 128, 47, 127] +1` | 46 → 47 | 127 → 128 |
| 47 | 6 | `[47, 77, 48, 76] +1` | 47 → 48 | 76 → 77 |

Crossing 48 is the one that matters: its transversal is `114 → 115`, so
rerouting through it recycles the label 115, and corridor step 4 then names
115.

<sub>Regenerate with (`--move` and the corridor arrows are on the unmerged
`orthodecorate` branch, not on `main`):<br>
`knoodledraw --mono --x-grid-size=3 --move="strand=81,83,85,87,89,91,93,95,97 depart=80 cross=7:u,42:u,8:u,230:u,131:u,281:u,260:u,290:u land=96" repro-underpass-zf061098.tsv`<br>
The `cross` darcs were derived independently from the `LeftDarc` face orbits
and came out identical to the path in the reproducer, which is a cross-check
on the darc convention in its own right.</sub>

What the picture is good for: it shows *why* this corridor is unusual — it
runs alongside W rather than cutting across the diagram, and so it re-crosses
transversals belonging to strand crossings it has already passed. That is the
configuration our ordering statistics below say `FindShortestPath` never
produces. At 73 crossings it is illustrative, not probative; the determinants
above and the table here are the actual evidence.

(The reproducer needs `Reroute` and `LoadDiagram` public; a two-line access
patch is in the handoff directory. It is not part of this PR.)

### Is this reachable from `SimplifyPasses`?

**Not on anything we can find, and the reason looks structural rather than
accidental.** I instrumented `Reroute` and swept `data/diagrams/*` plus
`tools/ExampleKnot.tsv`:

- 1,504,123 reroute path steps: **zero** entries needed redirection.
- Raising the search cap from `pass.arc_count-1` to `4*pass.arc_count` (so
  Dijkstra reports its true shortest corridor even where the improvement test
  will reject it) yields 4,612,650 corridors — still **zero**.

So the strict-improvement test is *not* what protects us. Breaking the 4.6M
corridors down by where they meet the interior crossings' transversals
(writing `x_i` for the i-th interior strand crossing, `j` for the corridor
step that names its transversal):

| | corridors |
|---|---|
| cross some transversal at all | 1,861,047 |
| &nbsp;&nbsp;at `j == i` | 1,771,272 |
| &nbsp;&nbsp;at `j < i` | 95,783 |
| &nbsp;&nbsp;**at `j > i`** (the aliasing case) | **0** |
| name an `a_0` at `j > i` | 0 |

`j == i` is your existing coincidence branch, and it is not rare — it is the
common case. What never happens is `j > i`.

That suggests an invariant worth stating outright, which I can support
empirically but have not proved:

> A corridor returned by `FindShortestPath` names the transversal of interior
> crossing `x_i` only at corridor steps `j ≤ i`.

If that holds, the aliasing is unreachable by construction: at step `j` every
label recycled so far belongs to a crossing with index `< j`, and `b_j` only
ever names transversals of index `≥ j`. The intuition is that the strand and
the corridor cobound a disk and the transversals leave it in order, so the
corridor cannot meet `t_i` after it has already passed `x_i` — but that is a
sketch, not an argument, and the disk is not obviously crossing-free.

The reproducer's corridor violates the invariant (`i` = 2, `j` = 4). It came
from a downstream port running a crossing-count-preserving tier, which we do
not have.

### About the patch — you will very likely think of something better

This is one way to close it, offered mainly so the report comes with
something concrete; please don't feel bound by it.

`A_succ` is a per-arc scratch table mapping each recycled label to the label
that absorbed its span; `path` entries are resolved through it, following
chains. `succ_front` records which entries a call dirtied so the reset costs
O(path length), not O(arc count) — nothing is allocated per call, which
matters given `Reroute` runs ~1.8M times on the link table alone.

Note the sentinel is `PD_T::Uninitialized`, deliberately **not** the
class-local `Uninitialized` at `PassSimplifier.hpp:60`, which is declared
`bool` and therefore evaluates to `1` — a perfectly valid arc label. (That
declaration also makes `Pass_T::first/last/next/mark` default to `1` rather
than `-1`. Harmless as far as I can tell, since they are always assigned
before use, but it looked like a landmine worth mentioning. I left it alone.)

**A narrower fix is entirely reasonable and may be what you prefer.** Your
doc-comment already says `Reroute` is private and not safe to call outside the
invariants `SimplifyStrands` guarantees, so tightening the contract — document
the ordering requirement and reject or assert on input that violates it — is a
legitimate answer to this report and would leave the hot path untouched. Our
interest is that the failure be *loud* rather than a silently wrong knot; how
that is achieved is your call.

### Regression

Patched vs unpatched, same build command, `knoodlesimplify` over
`data/diagrams/*`:

- byte-identical output on `linktable`, `hardgoeritz`, `randomunknots`,
  `veryhardunknots`, `tsunknots`, `hardunknots`;
- `childrensgame` differs on 2 of 38 files — but that corpus is **build**-
  sensitive, not patch-sensitive: two builds of *identical, unpatched* source
  differing only by an unused `-D` also disagree on it (it is 3D-geometry
  input, so the projection stage is evidently codegen-sensitive). The
  determinants agree on both files (159 and 117), and the redirect counter is
  zero there, so the patch cannot be the cause.

Prepared with Claude Code (Opus 5)



