### PR TITLE
PlanarDiagram: internal-state serialization for debugging

### DIFF
--- a/src/PlanarDiagram.hpp
+++ b/src/PlanarDiagram.hpp
@@ -461,6 +461,9 @@ namespace Knoodle
 #ifdef KNOODLE_USE_BOOST_PLANARITY
 #include "PlanarDiagram/Planarity.hpp"
 #endif
+
+#include "PlanarDiagram/WriteToOutString.hpp"
+#include "PlanarDiagram/ReadFromInString.hpp"
         
     public:
         

--- a/src/PlanarDiagram/ReadFromInString.hpp
+++ b/src/PlanarDiagram/ReadFromInString.hpp
@@ -1,0 +1,244 @@
+public:
+
+/*!@brief Reconstruct a diagram from the text written by
+ * `InternalStateString` / `WriteToOutString`.
+ *
+ * Deliberately tolerant: it looks up each field by name and ignores
+ * everything else, so a `PrintInfo` dump lifted out of a log file -- which
+ * carries surrounding log lines and the extra `CacheKeys()` field -- parses
+ * without editing. Fields may appear in any order.
+ *
+ * On any missing or malformed field an error is printed and an invalid
+ * diagram is returned, so a failed read cannot be mistaken for an empty one.
+ */
+
+static PD_T ReadFromInString( mref<Tools::InString> s )
+{
+    return FromInternalStateString( s.View() );
+}
+
+static PD_T ReadFromFile( cref<std::filesystem::path> file )
+{
+    Tools::InString s (file);
+
+    return ReadFromInString(s);
+}
+
+static PD_T FromInternalStateString( std::string_view text )
+{
+    auto fail = [&]( const std::string & msg ) -> PD_T
+    {
+        eprint(ClassName() + "::FromInternalStateString: " + msg
+               + ". Returning invalid diagram.");
+        return InvalidDiagram();
+    };
+
+    // Locate "<key> =", anchored so that `arc_count` does not match inside
+    // `max_arc_count`. Returns the offset just past the '='.
+    auto find_field = [&text]( std::string_view key ) -> std::size_t
+    {
+        for( std::size_t p = text.find(key); p != std::string_view::npos;
+             p = text.find(key, p + 1) )
+        {
+            const bool left_ok = (p == 0)
+                || (text[p-1] == '\n') || (text[p-1] == ' ')
+                || (text[p-1] == '\t') || (text[p-1] == '\r');
+
+            std::size_t q = p + key.size();
+            while( (q < text.size()) && ((text[q] == ' ') || (text[q] == '\t')) )
+            {
+                ++q;
+            }
+
+            if( left_ok && (q < text.size()) && (text[q] == '=') )
+            {
+                return q + 1;
+            }
+        }
+        return std::string_view::npos;
+    };
+
+    // Every value is either a scalar or a brace-nested list. In both cases we
+    // just want the tokens in order; the nesting is implied by the field's
+    // known shape, so we collect tokens until the braces balance again (or,
+    // for a scalar, until end of line).
+    auto tokens_of = [&text]( std::size_t pos, std::vector<std::string> & out )
+    {
+        out.clear();
+
+        std::size_t i = pos;
+        while( (i < text.size()) && ((text[i] == ' ') || (text[i] == '\t')) )
+        {
+            ++i;
+        }
+
+        const bool listQ = (i < text.size()) && (text[i] == '{');
+        Int depth = 0;
+        std::string tok;
+
+        auto flush = [&out,&tok]()
+        {
+            if( !tok.empty() ) { out.push_back(tok); tok.clear(); }
+        };
+
+        for( ; i < text.size(); ++i )
+        {
+            const char c = text[i];
+
+            if( c == '{' ) { flush(); ++depth; continue; }
+            if( c == '}' )
+            {
+                flush(); --depth;
+                if( depth <= 0 ) { return; }
+                continue;
+            }
+            if( (c == ',') || (c == ' ') || (c == '\t') || (c == '\r') )
+            {
+                flush(); continue;
+            }
+            if( c == '\n' )
+            {
+                flush();
+                if( !listQ ) { return; }
+                continue;
+            }
+            tok += c;
+        }
+        flush();
+    };
+
+    std::vector<std::string> tok;
+
+    auto scalar = [&]( std::string_view key, Int & out ) -> bool
+    {
+        const std::size_t p = find_field(key);
+        if( p == std::string_view::npos ) { return false; }
+        tokens_of(p, tok);
+        if( tok.size() != Size_T(1) ) { return false; }
+        try { out = static_cast<Int>(std::stoll(tok[0])); }
+        catch(...) { return false; }
+        return true;
+    };
+
+    Int max_c = 0, c_count = 0, max_a = 0, a_count = 0;
+    Int last_color = Uninitialized;
+    Int minimalQ = 0;
+
+    if( !scalar("max_crossing_count", max_c) )
+    {
+        return fail("field `max_crossing_count` missing or malformed");
+    }
+    // The remaining counts are re-derived by the constructor; we read them
+    // only to sanity-check the arrays below.
+    (void)scalar("crossing_count", c_count);
+    if( !scalar("max_arc_count", max_a) )
+    {
+        return fail("field `max_arc_count` missing or malformed");
+    }
+    (void)scalar("arc_count", a_count);
+    (void)scalar("last_color_deactivated", last_color);
+    (void)scalar("proven_minimalQ", minimalQ);
+
+    if( max_a != Int(2) * max_c )
+    {
+        return fail("max_arc_count = " + ToString(max_a)
+                    + " is not twice max_crossing_count = " + ToString(max_c));
+    }
+
+    auto read_ints = [&]( std::string_view key, Size_T n,
+                          std::vector<Int> & out ) -> bool
+    {
+        const std::size_t p = find_field(key);
+        if( p == std::string_view::npos ) { return false; }
+        tokens_of(p, tok);
+        if( tok.size() != n ) { return false; }
+        out.resize(n);
+        for( Size_T i = 0; i < n; ++i )
+        {
+            try { out[i] = static_cast<Int>(std::stoll(tok[i])); }
+            catch(...) { return false; }
+        }
+        return true;
+    };
+
+    const Size_T n_c = static_cast<Size_T>(max_c);
+    const Size_T n_a = static_cast<Size_T>(max_a);
+
+    std::vector<Int> crossings, arcs, colors;
+
+    if( !read_ints("C_arcs", Size_T(4) * n_c, crossings) )
+    {
+        return fail("field `C_arcs` missing, malformed, or not of length 4 * "
+                    + ToString(max_c));
+    }
+    if( !read_ints("A_cross", Size_T(2) * n_a, arcs) )
+    {
+        return fail("field `A_cross` missing, malformed, or not of length 2 * "
+                    + ToString(max_a));
+    }
+    if( !read_ints("A_color", n_a, colors) )
+    {
+        return fail("field `A_color` missing, malformed, or not of length "
+                    + ToString(max_a));
+    }
+
+    // The two state fields are written symbolically by `ToString`.
+    std::vector<CrossingState_T> c_states ( n_c );
+    {
+        const std::size_t p = find_field("C_state");
+        if( p == std::string_view::npos ) { return fail("field `C_state` missing"); }
+        tokens_of(p, tok);
+        if( tok.size() != n_c )
+        {
+            return fail("field `C_state` is not of length " + ToString(max_c));
+        }
+        for( Size_T i = 0; i < n_c; ++i )
+        {
+            if     ( tok[i] == "RightHanded" ) { c_states[i] = CrossingState_T::RightHanded; }
+            else if( tok[i] == "LeftHanded"  ) { c_states[i] = CrossingState_T::LeftHanded;  }
+            else if( tok[i] == "Inactive"    ) { c_states[i] = CrossingState_T::Inactive;    }
+            else { return fail("unknown crossing state `" + tok[i] + "`"); }
+        }
+    }
+
+    std::vector<ArcState_T> a_states ( n_a );
+    {
+        const std::size_t p = find_field("A_state");
+        if( p == std::string_view::npos ) { return fail("field `A_state` missing"); }
+        tokens_of(p, tok);
+        if( tok.size() != n_a )
+        {
+            return fail("field `A_state` is not of length " + ToString(max_a));
+        }
+        for( Size_T i = 0; i < n_a; ++i )
+        {
+            if     ( tok[i] == "Active"   ) { a_states[i] = ArcState_T::Active;   }
+            else if( tok[i] == "Inactive" ) { a_states[i] = ArcState_T::Inactive; }
+            else { return fail("unknown arc state `" + tok[i] + "`"); }
+        }
+    }
+
+    PD_T pd (
+        max_c,
+        crossings.data(), c_states.data(),
+        arcs.data(),      a_states.data(),
+        colors.data(),    last_color,
+        static_cast<bool>(minimalQ),
+        false   // compressQ: keep the labels we were given
+    );
+
+    if( (c_count > Int(0)) && (pd.CrossingCount() != c_count) )
+    {
+        wprint(ClassName() + "::FromInternalStateString: recomputed "
+               "crossing_count = " + ToString(pd.CrossingCount())
+               + " disagrees with the stored " + ToString(c_count) + ".");
+    }
+    if( (a_count > Int(0)) && (pd.ArcCount() != a_count) )
+    {
+        wprint(ClassName() + "::FromInternalStateString: recomputed "
+               "arc_count = " + ToString(pd.ArcCount())
+               + " disagrees with the stored " + ToString(a_count) + ".");
+    }
+
+    return pd;
+}

--- a/src/PlanarDiagram/WriteToOutString.hpp
+++ b/src/PlanarDiagram/WriteToOutString.hpp
@@ -1,0 +1,79 @@
+public:
+
+//##########################################################################
+//##    Internal-state serialization (debugging aid)
+//##########################################################################
+
+/*!@brief Serialize the diagram's full internal state as text.
+ *
+ * PD codes (and everything built on them) are produced by `Traverse` and
+ * therefore renumber crossings and arcs, drop inactive slots, and lose the
+ * distinction between `max_crossing_count` and `crossing_count`. That is
+ * exactly the information one needs when debugging a routine that mutates a
+ * diagram in place: which labels were recycled, which slots were deactivated,
+ * whether a crossing that was supposed to stay put actually did.
+ *
+ * The text produced here is the same `key = value` grammar that `PrintInfo`
+ * writes to the log, so a dump captured from a log file is valid input to
+ * `ReadFromInString` (and, as before, is a valid Mathematica list). The
+ * fields are exactly the arguments of the "construct from internal data"
+ * constructor, so the round trip is lossless up to the object cache, which is
+ * derived data and is not written.
+ *
+ * This is a debugging format, not an interchange format: the only contract is
+ * that the reader and writer shipped in the *same* release agree. Anything
+ * that has to survive a version change should use a PD code.
+ */
+
+std::string InternalStateString() const
+{
+    std::string s;
+
+    s += "PlanarDiagram\n";
+    s += "max_crossing_count = " + Tools::ToString(max_crossing_count) + "\n";
+    s += "crossing_count = "     + Tools::ToString(crossing_count)     + "\n";
+    s += "max_arc_count = "      + Tools::ToString(max_arc_count)      + "\n";
+    s += "arc_count = "          + Tools::ToString(arc_count)          + "\n";
+    s += "C_arcs = "             + ToString(C_arcs)                    + "\n";
+    s += "C_state = "            + ToString(C_state)                   + "\n";
+    s += "A_cross = "            + ToString(A_cross)                   + "\n";
+    s += "A_state = "            + ToString(A_state)                   + "\n";
+    s += "A_color = "            + ToString(A_color)                   + "\n";
+    s += "last_color_deactivated = "
+         + Tools::ToString(last_color_deactivated) + "\n";
+    s += "proven_minimalQ = "
+         + Tools::ToString(int(proven_minimalQ)) + "\n";
+
+    return s;
+}
+
+/*!@brief Append `InternalStateString` to an `OutString`. */
+
+void WriteToOutString( mref<Tools::OutString> s ) const
+{
+    const std::string str = InternalStateString();
+
+    s.PutChars( str.data(), str.size() );
+}
+
+/*!@brief Write the internal state to a file. Returns `false` if the file
+ * could not be opened.
+ */
+
+bool WriteToFile( cref<std::filesystem::path> file ) const
+{
+    std::ofstream stream;
+
+    stream.open(file, std::ofstream::out);
+
+    if( !stream )
+    {
+        eprint(MethodName("WriteToFile") + ": Could not open file "
+               + file.string() + ". Aborting.");
+        return false;
+    }
+
+    stream << InternalStateString();
+
+    return true;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -183,6 +183,15 @@ canon_check: canon_check.cpp ../Knoodle.hpp
 	    canon_check.cpp $(UMFPACK_LDFLAGS) -o $@
 	@echo "✓ canon_check compiled successfully"
 
+# pd_internal_state_check — round trip for PlanarDiagram's internal-state
+# serialization (WriteToOutString / ReadFromInString). Covers inactive slots
+# and max_* vs active counts, which PD codes cannot express, plus tolerance of
+# a PrintInfo dump lifted straight out of a log file. Light config.
+pd_internal_state_check: pd_internal_state_check.cpp ../Knoodle.hpp
+	@echo "=== Building pd_internal_state_check on $(UNAME_S) ==="
+	$(CXX) $(CXXFLAGS) $(KNOODLE_INC) pd_internal_state_check.cpp -o $@
+	@echo "✓ pd_internal_state_check compiled successfully"
+
 # component_check — regression guard for the CollapseArcRange unlink-loss bug
 # (Henrik's 5151f39). Embedded 8-crossing 2-component-unlink reproducer; default
 # Simplify must preserve the link-component count. Light config (no UMFPACK).

--- a/test/pd_internal_state_check.cpp
+++ b/test/pd_internal_state_check.cpp
@@ -1,0 +1,134 @@
+// Round-trip test for PlanarDiagram's internal-state serialization
+// (WriteToOutString / ReadFromInString).
+//
+// What it has to demonstrate, beyond "it parses":
+//   1. the text round trip is exact on an ordinary diagram;
+//   2. INACTIVE crossing/arc slots and the max_* vs active counts survive --
+//      this is the whole reason the format exists, since PD codes drop them;
+//   3. a dump lifted out of a log file parses unedited, surrounding log noise
+//      and the extra CacheKeys() field included;
+//   4. malformed input yields an invalid diagram rather than a crash or a
+//      silently empty one.
+
+#include "../Knoodle.hpp"
+
+#include <cstdio>
+#include <string>
+
+using Int  = std::int64_t;
+using PD_T = Knoodle::PlanarDiagram<Int>;
+
+static bool ok = true;
+
+static void check( bool passedQ, const char * what )
+{
+    std::printf("  %-58s %s\n", what, passedQ ? "OK" : "FAILED");
+    if( !passedQ ) { ok = false; }
+}
+
+int main()
+{
+    // ---- 1. exact round trip on a right-hand trefoil --------------------
+    {
+        Int code[] = { 0,4,1,3,1,  2,0,3,5,1,  4,2,5,1,1 };
+        PD_T pd = PD_T::FromSignedPDCode(&code[0], Int(3), false, false);
+
+        const std::string a  = pd.InternalStateString();
+        PD_T              pd2 = PD_T::FromInternalStateString(a);
+        const std::string b  = pd2.InternalStateString();
+
+        check(a == b,            "trefoil: text round trip is exact");
+        check(pd2.CheckAll(),    "trefoil: rebuilt diagram passes CheckAll");
+        check(pd2.CrossingCount() == pd.CrossingCount(),
+                                 "trefoil: crossing count preserved");
+        check(pd2.ArcCount()      == pd.ArcCount(),
+                                 "trefoil: arc count preserved");
+    }
+
+    // ---- 2. inactive slots and label preservation -----------------------
+    // A trefoil living in arrays sized for four crossings: slot 3 and arcs
+    // 6, 7 are inactive. A PD code cannot express this at all; the point of
+    // the format is that it comes back unchanged.
+    {
+        const std::string padded =
+            "PlanarDiagram\n"
+            "max_crossing_count = 4\n"
+            "crossing_count = 3\n"
+            "max_arc_count = 8\n"
+            "arc_count = 6\n"
+            "C_arcs = {\n"
+            " { { 1, 4 }, { 3, 0 } },\n"
+            " { { 3, 0 }, { 5, 2 } },\n"
+            " { { 5, 2 }, { 1, 4 } },\n"
+            " { { -1, -1 }, { -1, -1 } }\n"
+            "}\n"
+            "C_state = { RightHanded, RightHanded, RightHanded, Inactive }\n"
+            "A_cross = {\n"
+            " { 1, 0 },\n { 0, 2 },\n { 2, 1 },\n"
+            " { 1, 0 },\n { 0, 2 },\n { 2, 1 },\n"
+            " { -1, -1 },\n { -1, -1 }\n"
+            "}\n"
+            "A_state = { Active, Active, Active, Active, Active, Active,"
+            " Inactive, Inactive }\n"
+            "A_color = { 0, 0, 0, 0, 0, 0, -1, -1 }\n"
+            "last_color_deactivated = -1\n"
+            "proven_minimalQ = 0\n";
+
+        PD_T pd = PD_T::FromInternalStateString(padded);
+
+        check(pd.MaxCrossingCount() == Int(4),
+              "inactive slots: max_crossing_count kept at 4");
+        check(pd.CrossingCount() == Int(3),
+              "inactive slots: active crossing count is 3");
+        check(pd.MaxArcCount() == Int(8),
+              "inactive slots: max_arc_count kept at 8");
+        check(pd.ArcCount() == Int(6),
+              "inactive slots: active arc count is 6");
+        check(pd.CheckAll(), "inactive slots: CheckAll passes");
+        check(pd.InternalStateString() == padded,
+              "inactive slots: re-serializes to the identical text");
+    }
+
+    // ---- 3. tolerance: a dump lifted out of a log file -------------------
+    {
+        Int code[] = { 0,4,1,3,1,  2,0,3,5,1,  4,2,5,1,1 };
+        PD_T pd = PD_T::FromSignedPDCode(&code[0], Int(3), false, false);
+
+        const std::string body = pd.InternalStateString();
+
+        std::string logged =
+            "PlanarDiagram<I64>::PrintInfo -- begin\n"
+            + body +
+            "this->CacheKeys() = { ArcLeftDarcs, DiagramComponents }\n"
+            "PlanarDiagram<I64>::PrintInfo -- end\n";
+
+        PD_T pd2 = PD_T::FromInternalStateString(logged);
+
+        check(pd2.CheckAll(), "log dump: parses with surrounding log lines");
+        check(pd2.InternalStateString() == body,
+              "log dump: recovers the same state");
+    }
+
+    // ---- 4. malformed input is refused, not guessed ---------------------
+    {
+        PD_T bad1 = PD_T::FromInternalStateString("PlanarDiagram\n");
+        check(bad1.InvalidQ(), "malformed: empty body -> invalid diagram");
+
+        PD_T bad2 = PD_T::FromInternalStateString(
+            "max_crossing_count = 3\nmax_arc_count = 5\n");
+        check(bad2.InvalidQ(),
+              "malformed: max_arc_count != 2 * max_crossing_count -> invalid");
+
+        PD_T bad3 = PD_T::FromInternalStateString(
+            "max_crossing_count = 1\nmax_arc_count = 2\n"
+            "C_arcs = { { { 1, 0 }, { 1, 0 } } }\n"
+            "C_state = { Sideways }\n"
+            "A_cross = { { 0, 0 }, { 0, 0 } }\n"
+            "A_state = { Active, Active }\n"
+            "A_color = { 0, 0 }\n");
+        check(bad3.InvalidQ(), "malformed: unknown crossing state -> invalid");
+    }
+
+    std::printf(ok ? "CASE OK\n" : "CASE FAILED\n");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
A debuggability request rather than a feature: a way to get a `PlanarDiagram`
out of the process and back in **with its labels intact**.

### Why PD codes don't serve here

`WritePDCode` goes through `Traverse`, so it emits traversal *positions*. That
means a PD code renumbers crossings and arcs, drops inactive slots, and
collapses `max_crossing_count` vs `crossing_count`. All three are exactly the
things one wants to look at when debugging a routine that mutates a diagram in
place — which labels got recycled, which slots were deactivated, whether a
crossing that was supposed to stay put actually did.

Concretely: we have been debugging `PassSimplifier::Reroute` against a
73-crossing reproducer, and wanted to compare the diagram before and after the
move. Internally the two anchor crossings are untouched —

```
BEFORE:  crossing 40 = { { 121, 40 }, { 39, 120 } } (RightHanded)
AFTER:   crossing 40 = { { 121, 40 }, { 39, 120 } } (RightHanded)
```

— but through PD codes **0 of 73 rows survive at the same index**, so the
correspondence between the two states is gone and there is nothing left to
compare. `PlanarDiagramComplex::WriteToFile` doesn't help either: it round
trips colours, summand structure and the proven-minimal flag, but the bodies
are still `WritePDCode`.

### What this adds

Both halves of the round trip already existed separately — `PrintInfo` dumps
the state, and the "construct from internal data" constructor consumes exactly
those fields — there was just no way to get from the one to the other in C++.
This connects them:

```cpp
std::string InternalStateString() const;
void        WriteToOutString( mref<Tools::OutString> ) const;
bool        WriteToFile( cref<std::filesystem::path> ) const;

static PD_T FromInternalStateString( std::string_view );
static PD_T ReadFromInString( mref<Tools::InString> );
static PD_T ReadFromFile( cref<std::filesystem::path> );
```

The emitted text is the same `key = value` grammar `PrintInfo` writes, so:

* a dump captured from a **log file** is valid input to the reader with no
  editing — the parser looks fields up by name and ignores everything else,
  including the surrounding log lines and the extra `CacheKeys()` field;
* it stays a valid Mathematica list, so the notebooks in `KnoodleLink` that
  already scrape `C_arcs = {` and `A_cross = {` out of `PrintInfo` output keep
  working on it.

Header-only and purely additive. `PrintInfo` is untouched, nothing existing
changes behaviour, and the two new headers are included after the rest of the
class.

### On stability

This is a debugging format, not an interchange format, and I'd suggest it
carry no compatibility promise beyond: **the reader and writer shipped in the
same release agree with each other.** If a dump happens to survive a version
bump that's a bonus, not a contract — artifacts of this kind are expected to
be ephemeral, and anything that has to outlive a release should still be a PD
code. That keeps you free to add or reorder members without treating it as a
breaking change.

### Tests

`test/pd_internal_state_check` (light config, no UMFPACK) covers:

1. exact text round trip on a trefoil;
2. **inactive slots and the `max_*` counts** — a trefoil living in arrays
   sized for four crossings comes back byte-identical, which no PD code can
   express;
3. a `PrintInfo` dump lifted out of a log, log noise and `CacheKeys()`
   included, parses and recovers the same state;
4. malformed input (missing field, inconsistent `max_arc_count`, unknown state
   name) returns an invalid diagram rather than crashing or silently reading
   as empty.

All 15 checks pass; `knoodlesimplify` and `knoodledraw` rebuild unchanged.

Happy to rename anything — I matched `PlanarDiagramComplex`'s
`WriteToOutString` / `ReadFromFile` naming, but the internal-state form is
distinct enough from the PD-code form that clearer names may be worth it.

Prepared with Claude Code (Opus 5)
