### PR TITLE
Fix PlanarDiagram::FaceString, which never compiled

### DIFF
--- a/src/PlanarDiagram/Faces.hpp
+++ b/src/PlanarDiagram/Faces.hpp
@@ -4,14 +4,14 @@ public:
 std::string FaceString( const Int f ) const
 {
     cptr<Int> F_dA_ptr = FaceDarcs().Pointers().data();
-    cptr<Int> F_dA_idx = FaceDarcs().Indices().data();
+    cptr<Int> F_dA_idx = FaceDarcs().Elements().data();
     
     const Int i_begin = F_dA_ptr[f  ];
     const Int i_end   = F_dA_ptr[f+1];
     
     const Int f_size = i_end - i_begin;
     
-    return "face " + ToString(f) + " = " + OutString::FromVector( &F_dA_idx[i_begin], f_size );
+    return "face " + ToString(f) + " = " + std::string(OutString::FromVector( &F_dA_idx[i_begin], f_size ));
     
 }
 

--- a/test/diagram_sanity_check.cpp
+++ b/test/diagram_sanity_check.cpp
@@ -137,6 +137,25 @@ int main()
                && KnoodleTest::DiagramSanityQ(trefoil),
            "trefoil with warm cache still passes (stale-cache arm agrees)" );
 
+    // `FaceString` is a debugging accessor nobody calls, so a typo in it never
+    // fails to compile (it called `RaggedList::Indices()`, which does not
+    // exist, for a long time). Instantiate it on every face and check that it
+    // lists exactly the darcs FaceDarcs() does, so it cannot rot again.
+    {
+        const auto & F_dA = trefoil.FaceDarcs();
+        bool okQ = true;
+        for( Int f = 0; f < trefoil.FaceCount(); ++f )
+        {
+            const Int i_begin = F_dA.Pointers()[f  ];
+            const Int i_end   = F_dA.Pointers()[f+1];
+            std::string want = "face " + std::to_string((long long)f) + " = "
+                             + std::string(Tools::OutString::FromVector(
+                                   &F_dA.Elements()[i_begin], i_end - i_begin ));
+            okQ = okQ && ( trefoil.FaceString(f) == want );
+        }
+        check( okQ, "FaceString(f) compiles and lists FaceDarcs() for every face" );
+    }
+
     // An invalid diagram is corrupt by definition here.
     {
         PD_T invalid = PD_T::InvalidDiagram();


### PR DESCRIPTION
`FaceString` is a debugging accessor with no callers, so as a member of a class template it was never instantiated and two typos went unnoticed:

- it calls `RaggedList::Indices()`, which does not exist (the accessor is `Elements()`, `Tensors/src/RaggedList.hpp:155`);
- it concatenates a `std::string` with an `OutString`, which has no `operator+`. Wrapped in `std::string(...)`, the same idiom `WideInt.hpp:572` already uses.

Same disease as the PDC copy ctor (#35): a template member nobody instantiates can't go red.

`test/diagram_sanity_check.cpp` now calls `FaceString(f)` on every face of the trefoil and checks it against `FaceDarcs()`, so the function is instantiated in the light tier and can't rot again. Based on `dev_prosector` because that test file only exists there; the `Faces.hpp` hunk is independent and cherry-picks cleanly onto `main` if wanted sooner.

`make -C test check`: 30 passed, 0 failed.

Prepared with Claude Code (Fable 5)
