### PR TITLE
test: put the 32-bit backend (i32) in embedding_check's default set

### DIFF
--- a/docs/embedding-check.md
+++ b/docs/embedding-check.md
@@ -110,10 +110,12 @@ Two consequences, both in the code:
   re-aiming re-aims, knot type is constant, no upward trend — all still hold, and they
   are the ones that carry the claim.
 
-`i32` (the 32-bit backend) still does not build — finding
-[D](#d-the-32-bit-backend-does-not-compile) is half fixed — and stays behind
-`-DKNOODLE_TEST_INT32_BACKEND`. The binary prints which combinations it could not build;
-it does not skip them silently.
+`i32` (the 32-bit backend) is in the default set as of 2026-08-25: finding
+[D](#d-the-32-bit-backend-does-not-compile) is fixed upstream and the
+`-DKNOODLE_TEST_INT32_BACKEND` gate is gone. Its `Real_` is `float`, so every marker
+scoped `@f32` is also scoped `@i32` — the same precision limits apply, and the two
+`i32` fixtures that fail today (`nearmiss_sphere`, `deg_stacked_points`) fail for the
+f32 reasons already recorded, not for anything 32-bit.
 
 The integral-coordinate *path* is exercised regardless: `ReadVertexCoordinates` detects
 all-integral input and sets `scaling_exponent = 0`, so integer-valued doubles take the
@@ -423,7 +425,7 @@ harness. Severity is my read; the evidence is the part that matters.
 | A | `FromLinkEmbedding(LinkEmbedding2&)` treats success as error | **fixed** — `1d8761c7` + `34cd0fc3` |
 | B | zero-length edges rejected as 3D intersections | **open** |
 | C | integral `Real_` does not compile | **fixed** — `4d2d0624` |
-| D | the 32-bit backend does not compile | **half** — `Sign` resolved, `WideInt` remains |
+| D | the 32-bit backend does not compile | **fixed** — `7ca90e8a`; in the default set since 2026-08-25 |
 | E | `RequireIntersections` segfaults on a triple point | **fixed** — `d26c301f` |
 | F | `FromInString` has two inverted assertions | **fixed** — `8db4cdc4` |
 | G | `Transform` does not invalidate its caches | **fixed** — `8db4cdc4` |
@@ -575,23 +577,22 @@ currently promise something that does not build. Behind `-DKNOODLE_TEST_INTEGER_
 
 ### D. The 32-bit backend does not compile
 
-**HALF FIXED at `fb4c8f0e`.** The `Prosector2` ambiguity is gone; what remains is
-`src/WideInt.hpp:114`, *"excess elements in array initializer"*. Henrik is mid-flight
-here — the `__int128` commits of 2026-08-14 end in a `Rollback` — and notes in
-`4d2d0624` that `int32_t` as `IReal` is problematic anyway because two `WInt32` do not
-`long_mul` into a `WInt64`, *"and we want Int64 here anyways for performance reasons"*.
-So this may well close by narrowing the documentation rather than by making the pairing
-work, which would be a fine outcome; the defect is that the docs promise something that
-does not build.
+**FIXED.** The `Prosector2` `Sign` ambiguity went at `fb4c8f0e`; the `WideInt`
+*"excess elements in array initializer"* went with `7ca90e8a` ("Refined long_mul for
+built-in integral classes"). Verified 2026-08-25: all four classes build with
+`Real_ = float`, `IReal_ = int32_t`, and the `--coords=i32` tier runs. The
+`-DKNOODLE_TEST_INT32_BACKEND` gate is removed and `i32` is in the default set.
 
-**Severity: low, but the docs recommend this pairing.**
+What the tier shows is that `i32` is `f32` with an integer backend: every failure it
+has is one `f32` already has (`nearmiss_sphere` cannot be resolved at a 10^4 : 1 scale
+ratio in `float`; `deg_stacked_points` under a float rotation is finding B). The
+markers on those two fixtures are scoped `@f32,i32` accordingly. No 32-bit-specific
+defect was found.
 
-The docs suggest `Real_ = float` with `IReal_ = int32_t`. Neither works:
-
-- `Prosector2`: `call to 'Sign' is ambiguous`, `src/Prosector2/Helpers.hpp:16` (also 19, 21).
-- `Prosector3`, `Prosector4`: `excess elements in array initializer`, `src/WideInt.hpp:112`.
-
-Behind `-DKNOODLE_TEST_INT32_BACKEND`.
+Historical record: the docs recommended `Real_ = float` with `IReal_ = int32_t`, and
+for a while neither worked — `call to 'Sign' is ambiguous` at
+`src/Prosector2/Helpers.hpp:16` (also 19, 21), and `excess elements in array
+initializer` at `src/WideInt.hpp:112` for `Prosector3`/`Prosector4`.
 
 ### E. `LinkEmbedding::RequireIntersections` segfaults on a triple point
 

--- a/docs/upstream-issues.md
+++ b/docs/upstream-issues.md
@@ -448,11 +448,11 @@ Detail: [embedding-check.md §5B](embedding-check.md#b-zero-length-edges-are-rej
 
 ## 4. `LinkEmbedding2/3/4` do not compile with the 32-bit backend
 
-**Status:** HALF FIXED at `fb4c8f0e`. The `Prosector2` `Sign` ambiguity is gone;
-`src/WideInt.hpp:114` "excess elements in array initializer" remains, and the
-`__int128` work of 2026-08-14 ends in a `Rollback`. May close by narrowing the
-docs instead: `4d2d0624` notes `int32_t` as `IReal` is problematic anyway, and
-"we want Int64 here anyways for performance reasons".
+**Status:** FIXED, verified 2026-08-25. The `Prosector2` `Sign` ambiguity went
+at `fb4c8f0e`, the `WideInt` initializer error with `7ca90e8a`. All four classes
+now build with `Real_ = float`, `IReal_ = int32_t`; `test/embedding_check` runs
+the `i32` tier by default (the `-DKNOODLE_TEST_INT32_BACKEND` gate is gone). Its
+only failures are the ones `f32` already has — no 32-bit-specific defect.
 Confirmed 2026-08-13. **Severity:** low, but the class docs
 recommend the `Real_ = float`, `IReal_ = int32_t` pairing.
 

--- a/test/embedding_check.cpp
+++ b/test/embedding_check.cpp
@@ -90,10 +90,10 @@ using Alexander_T = kt::LinkAlexander<std::complex<double>,std::int64_t>;
 //        Henrik speaking: This should resolved by now (2026-08-17).
 //
 //   i32  The 32-bit backend (`IReal_ = Int32`), which the class docs recommend
-//        pairing with `Real_ = float`. Prosector2 hits an ambiguous `Sign` call
-//        (src/Prosector2/Helpers.hpp:16); Prosector3 and Prosector4 hit
-//        "excess elements in array initializer" at src/WideInt.hpp:112.
-//        Enable with -DKNOODLE_TEST_INT32_BACKEND.
+//        pairing with `Real_ = float`. Did not compile until 2026-08 (upstream
+//        issue 4: ambiguous `Sign` in Prosector2, "excess elements in array
+//        initializer" in WideInt for Prosector3/4); in the default set as of
+//        2026-08-25. Its Real_ is float, so it inherits every @f32 marker.
 //        Henrik speaking: This should resolved by now (2026-08-17).
 //
 // The integral-coordinate *path* is nevertheless exercised by default:
@@ -114,12 +114,10 @@ using LE2_f32 = Knoodle::LinkEmbedding2<float,std::int64_t,std::int64_t>;
 using LE3_f32 = Knoodle::LinkEmbedding3<float,std::int64_t,std::int64_t>;
 using LE4_f32 = Knoodle::LinkEmbedding4<float,std::int64_t,std::int64_t>;
 
-#ifdef KNOODLE_TEST_INT32_BACKEND
 using LE1_i32 = Knoodle::LinkEmbedding <float,std::int64_t,float>;
 using LE2_i32 = Knoodle::LinkEmbedding2<float,std::int64_t,std::int32_t>;
 using LE3_i32 = Knoodle::LinkEmbedding3<float,std::int64_t,std::int32_t>;
 using LE4_i32 = Knoodle::LinkEmbedding4<float,std::int64_t,std::int32_t>;
-#endif
 
 // Integral `Real_`. Unbuildable until 4d2d0624 implemented it (finding C of
 // docs/embedding-check.md); no longer gated.
@@ -158,19 +156,6 @@ static bool SupportedQ( int cls, Coords c, std::string & why )
             return false;
         }
     }
-    if( c == Coords::i32 )
-    {
-#ifndef KNOODLE_TEST_INT32_BACKEND
-        if( cls != 1 )
-        {
-            why = "the 32-bit backend does not compile (Prosector2: ambiguous Sign at "
-                  "src/Prosector2/Helpers.hpp:16; Prosector3/4: excess elements in array "
-                  "initializer at src/WideInt.hpp:112); rebuild with "
-                  "-DKNOODLE_TEST_INT32_BACKEND once fixed";
-            return false;
-        }
-#endif
-    }
     (void)cls;
     return true;
 }
@@ -205,7 +190,6 @@ static bool WithClass( int cls, Coords c, Fn && fn )
             default: return false;
         }
     }
-#ifdef KNOODLE_TEST_INT32_BACKEND
     if( c == Coords::i32 )
     {
         switch( cls )
@@ -217,7 +201,6 @@ static bool WithClass( int cls, Coords c, Fn && fn )
             default: return false;
         }
     }
-#endif
     if( c == Coords::i64 )
     {
         switch( cls )

--- a/test/embeddings/deg_stacked_points.expect
+++ b/test/embeddings/deg_stacked_points.expect
@@ -48,4 +48,4 @@ xcrash_symmetry  = 2,3,4   | assertion in LinesColinearTest: two distinct degene
 # finding B (a zero-length edge makes its two neighbours share a point of
 # 3-space), a different defect with a different outcome.
 xcrash_rotation  = 2,3,4 @i64     | assertion in LinesColinearTest: two distinct degenerate segments (upstream issue 11)
-xfail_rotation   = 2,3,4 @f64,f32 | zero-length edge makes its neighbours meet in 3D (finding B)
+xfail_rotation   = 2,3,4 @f64,f32,i32 | zero-length edge makes its neighbours meet in 3D (finding B)

--- a/test/embeddings/nearmiss_sphere.expect
+++ b/test/embeddings/nearmiss_sphere.expect
@@ -57,7 +57,7 @@ max_point_multiplicity == 2
 transversal            == 4512
 spatial                == 0
 
-xfail_cross     = 1 @f32       | f32 cannot resolve a 10^4 : 1 scale ratio; refuses with code 8, and with code 6 misdiagnoses it as a 3D self-intersection
-xfail_invariant = 1 @f32       | same, on the generic rotation this class is anchored to
-xfail_rotation  = 1 @f32       | same, on the anchoring projection
-xfail_rotation  = 2,3,4 @f32   | composing 24 rotations in f32 degrades the curve itself at this scale; the exact classes then correctly diagram the degraded curve. f64 unaffected
+xfail_cross     = 1 @f32,i32       | f32 cannot resolve a 10^4 : 1 scale ratio; refuses with code 8, and with code 6 misdiagnoses it as a 3D self-intersection
+xfail_invariant = 1 @f32,i32       | same, on the generic rotation this class is anchored to
+xfail_rotation  = 1 @f32,i32       | same, on the anchoring projection
+xfail_rotation  = 2,3,4 @f32,i32   | composing 24 rotations in f32 degrades the curve itself at this scale; the exact classes then correctly diagram the degraded curve. f64 unaffected


### PR DESCRIPTION
Test/docs only — no `src/` changes.

Upstream issue 4 (LinkEmbedding2/3/4 don't compile with `IReal_ = int32_t`) is fixed: the `Prosector2` `Sign` ambiguity went at fb4c8f0e and the `WideInt` "excess elements in array initializer" with 7ca90e8a. All four classes now build with `Real_ = float`, `IReal_ = int32_t`, so this removes the `-DKNOODLE_TEST_INT32_BACKEND` compile gate in `test/embedding_check.cpp`; the `i32` tier runs whenever `--coords` lists it (the heavy tier's args already do).

Running it shows `i32` is `f32` with an integer backend: its only failures are ones `f32` already has (`nearmiss_sphere` can't be resolved at a 10^4 : 1 scale ratio in float; `deg_stacked_points` under a float rotation is finding B / issue 5). Those markers are widened from `@f32` to `@f32,i32`. No 32-bit-specific defect surfaced.

- Heavy args (`--coords=f64,f32,i32,i64 --rotations=8`): passed 2762, failed 0, 0 XPASS (43 i32 checks, up from 0).
- Light tier: 30 passed, 0 failed.
- `docs/embedding-check.md` finding D and `docs/upstream-issues.md` issue 4 marked fixed.

Prepared with Claude Code (Fable 5)
